### PR TITLE
Fix scenarios around committing the page map

### DIFF
--- a/src/coreclr/gc/satori/SatoriHeap.h
+++ b/src/coreclr/gc/satori/SatoriHeap.h
@@ -136,13 +136,13 @@ public:
     }
 
 private:
-    // We need to cover the whole possible address space.
-    // No need to reason about inaccessible VA as accessing it wil fail either way.
-    // - on x64 canonical user VA  uses lower 47 bits (128 TB)
-    // - arm64 allowes 48 lower bits (256 TB), although some OS use same 47 as on x64.
-    // - we can support 53 bit (4 PB) and 57 bit (??) extensions, but too early to worry about that.
-    // 
-    // For consistency and uniform testing, we will default to 48 bit.
+    // We need to cover the whole addressable space, but no need to handle inaccessible VA.
+    // Accessing that should not happen for any valid reason, and will fail anyway.
+    // - the canonical user VA on x64 uses lower 47 bits (128 TB)
+    // - arm64 allows 48 lower bits (256 TB), linux uses that, but other OS use the same range as on x64.
+    // - we can eventually support 53 bit (4 PB) and 57 bit (??) extensions, it is too early to worry about that.
+    //
+    // For consistency and uniform testing, we will default to 48 bit VA.
     static const int availableAddressSpaceBits = 48;
     static const int pageCountBits = availableAddressSpaceBits - Satori::PAGE_BITS;
 

--- a/src/coreclr/gc/satori/SatoriHeap.h
+++ b/src/coreclr/gc/satori/SatoriHeap.h
@@ -154,6 +154,12 @@ private:
     size_t m_usedMapLength;
     size_t m_nextPageIndex;
     SatoriLock m_mapLock;
+
+#if _DEBUG
+    // make the Heap obj a bit larger to force some page map commits earlier.
+    int8_t dummy[0x7A70]{};
+#endif
+
     SatoriPage* m_pageMap[1];
 
     bool CommitMoreMap(size_t currentlyCommitted);

--- a/src/coreclr/gc/satori/SatoriHeap.h
+++ b/src/coreclr/gc/satori/SatoriHeap.h
@@ -136,8 +136,14 @@ public:
     }
 
 private:
-    // we need to cover the whole possible address space (48bit, 52 may be supported as needed).
-    static const int availableAddressSpaceBits = 47;
+    // We need to cover the whole possible address space.
+    // No need to reason about inaccessible VA as accessing it wil fail either way.
+    // - on x64 canonical user VA  uses lower 47 bits (128 TB)
+    // - arm64 allowes 48 lower bits (256 TB), although some OS use same 47 as on x64.
+    // - we can support 53 bit (4 PB) and 57 bit (??) extensions, but too early to worry about that.
+    // 
+    // For consistency and uniform testing, we will default to 48 bit.
+    static const int availableAddressSpaceBits = 48;
     static const int pageCountBits = availableAddressSpaceBits - Satori::PAGE_BITS;
 
     int8_t m_pageByteMap[1 << pageCountBits]{};

--- a/src/coreclr/gc/satori/SatoriPage.cpp
+++ b/src/coreclr/gc/satori/SatoriPage.cpp
@@ -58,7 +58,6 @@ SatoriPage* SatoriPage::InitializeAt(size_t address, size_t pageSize, SatoriHeap
 
     if (!GCToOSInterface::VirtualCommit((void*)address, commitSize))
     {
-        GCToOSInterface::VirtualRelease((void*)address, pageSize);
         return nullptr;
     }
 

--- a/src/coreclr/gc/satori/SatoriRecycler.cpp
+++ b/src/coreclr/gc/satori/SatoriRecycler.cpp
@@ -1239,11 +1239,14 @@ void SatoriRecycler::BlockingCollectImpl()
     Relocate();
     Update();
 
-    _ASSERTE(m_activeWorkers == 0);
-
     // we are done using workers.
     // undo the adjustment if we had to do one
-    if (IsWorkerThread()) m_activeWorkers++;
+    if (IsWorkerThread())
+    {
+        // interlocked because even though we saw no workers after m_activeWorkerFn was reset,
+        // some delayed workers may later still come and look for work.
+        Interlocked::Increment(&m_activeWorkers);
+    }
 
     m_gcCount[0]++;
     m_gcCount[1]++;

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -581,7 +581,7 @@ void* GCToOSInterface::VirtualReserve(void* location, size_t size, bool useTHP)
         return NULL;
     }
 
-    if (pRetVal != location)
+    if (location != nullptr && pRetVal != location)
     {
         munmap(pRetVal, size);
         return NULL;

--- a/src/coreclr/vm/amd64/jitinterfaceamd64.cpp
+++ b/src/coreclr/vm/amd64/jitinterfaceamd64.cpp
@@ -881,7 +881,7 @@ int WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSus
     // we need to switch to the WriteBarrier_PostGrow function for good.
 
 #ifdef FEATURE_SATORI_GC
-    // as of now satori does not patch barriers on x64
+    // as of now satori does not patch barriers on x64, no need to go further.
     return SWB_PASS;
 #endif
 

--- a/src/coreclr/vm/amd64/jitinterfaceamd64.cpp
+++ b/src/coreclr/vm/amd64/jitinterfaceamd64.cpp
@@ -880,6 +880,11 @@ int WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSus
     // If we are told that we require an upper bounds check (GC did some heap reshuffling),
     // we need to switch to the WriteBarrier_PostGrow function for good.
 
+#ifdef FEATURE_SATORI_GC
+    // as of now satori does not patch barriers on x64
+    return SWB_PASS;
+#endif
+
     WriteBarrierType newType;
     if (NeedDifferentWriteBarrier(bReqUpperBoundsCheck, g_region_use_bitwise_write_barrier, &newType))
     {


### PR DESCRIPTION
Fixes: #41 

Some notes:
* Since it is technically Undefined Behavior, the OS can be randomly lenient about committing unreserved memory. Especially Linux. Added a few asserts in key places to catch things in tests.
* Assumption that canonical 47bit VA is a good default for everybody is not correct on Linux arm64, which may use 48th bit. 
We could be a bit more frugal on other platforms, but the savings are relatively small and do not seem worth to have differences, especially from testing point of view. So will go with 48 bit VA default per Linux-arm64 being common denominator.