### PR TITLE
Revert "Report collection counts non-inclusively"

### DIFF
--- a/src/coreclr/gc/satori/SatoriGC.cpp
+++ b/src/coreclr/gc/satori/SatoriGC.cpp
@@ -197,26 +197,13 @@ unsigned SatoriGC::WhichGeneration(Object* obj)
 
 int SatoriGC::CollectionCount(int generation, int get_bgc_fgc_coutn)
 {
-    // get_bgc_fgc_coutn - not sure what this is. thus N/A
-
+    //get_bgc_fgc_coutn N/A
     if ((unsigned)generation > (unsigned)2)
     {
         return 0;
     }
 
-    int64_t count = m_heap->Recycler()->GetCollectionCount(generation);
-
-    // in the public API GC counts are not inclusive
-    if (generation < 1)
-    {
-        count -= m_heap->Recycler()->GetCollectionCount(1);
-    }
-    else if (generation < 2)
-    {
-        count -= m_heap->Recycler()->GetCollectionCount(2);
-    }
-
-    return (int)count;
+    return (int)m_heap->Recycler()->GetCollectionCount(generation);
 }
 
 int SatoriGC::StartNoGCRegion(uint64_t totalSize, bool lohSizeKnown, uint64_t lohSize, bool disallowFullBlockingGC)
@@ -373,8 +360,6 @@ bool SatoriGC::IsGCInProgressHelper(bool bConsiderGCStart)
     return m_gcInProgress;
 }
 
-// this is basically a GC index
-// it is used in suspend events, and in GC stress.
 unsigned SatoriGC::GetGcCount()
 {
     if (!m_heap)
@@ -382,7 +367,7 @@ unsigned SatoriGC::GetGcCount()
         return 0;
     }
 
-    return (unsigned)(int)m_heap->Recycler()->GetCollectionCount(/*gen*/ 0);
+    return (unsigned)(int)m_heap->Recycler()->GetCollectionCount(/*gen*/ 1);
 }
 
 bool SatoriGC::IsThreadUsingAllocationContextHeap(gc_alloc_context* acontext, int thread_number)


### PR DESCRIPTION
Reverts VSadov/Satori#51

On a deeper examination it turns out the numbers should be reported inclusively:
- a gen2 increments counts for gen2, gen1 and gen0
- a gen1 increments counts for gen1 and gen0
- a gen0 increments counts for gen0

Another invariant - the number of Gen0 collections will never be less than number of Gen2 collections. And total number of collections is the same as number of Gen0 collections.

Here is where the default GC increments all the counts up to condemned generation: 
https://github.com/VSadov/Satori/blob/50b175bcbbd5ce5a8a6586d2738a9b8db8efd334/src/coreclr/gc/gc.cpp#L23557-L23560