### PR TITLE
Follow up to https://github.com/VSadov/Satori/pull/56

### DIFF
--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
@@ -518,12 +518,12 @@ ALTERNATE_ENTRY RhpAssignRefAVLocation
         // also save xmm0, in case it is used for stack clearing, as JIT_ByRefWriteBarrier should not trash xmm0
         // Hopefully EscapeFn cannot corrupt other xmm regs, since there is no float math or vectorizable code in there.
         sub     rsp, 16
-        movdqu  [rsp], xmm0
+        movdqa  [rsp], xmm0
 
         // void SatoriRegion::EscapeFn(SatoriObject** dst, SatoriObject* src, SatoriRegion* region)
         call    qword ptr [rdx + 8]
 
-        movdqu  xmm0, [rsp]
+        movdqa  xmm0, [rsp]
         add     rsp, 16
 
         pop     r10

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
@@ -517,7 +517,7 @@ ALTERNATE_ENTRY RhpAssignRefAVLocation
         ; also save xmm0, in case it is used for stack clearing, as JIT_ByRefWriteBarrier should not trash xmm0
         ; Hopefully EscapeFn cannot corrupt other xmm regs, since there is no float math or vectorizable code in there.
         sub     rsp, 16
-        movdqu  [rsp], xmm0
+        movdqa  [rsp], xmm0
 
         ; shadow space
         sub  rsp, 20h
@@ -527,7 +527,7 @@ ALTERNATE_ENTRY RhpAssignRefAVLocation
 
         add     rsp, 20h
 
-        movdqu  xmm0, [rsp]
+        movdqa  xmm0, [rsp]
         add     rsp, 16
 
         pop     r8

--- a/src/coreclr/vm/amd64/patchedcode.S
+++ b/src/coreclr/vm/amd64/patchedcode.S
@@ -446,12 +446,12 @@ LEAF_ENTRY JIT_WriteBarrier, _TEXT
         // also save xmm0, in case it is used for stack clearing, as JIT_ByRefWriteBarrier should not trash xmm0
         // Hopefully EscapeFn cannot corrupt other xmm regs, since there is no float math or vectorizable code in there.
         sub     rsp, 16
-        movdqu  [rsp], xmm0
+        movdqa  [rsp], xmm0
 
         // void SatoriRegion::EscapeFn(SatoriObject** dst, SatoriObject* src, SatoriRegion* region)
         call    qword ptr [rdx + 8]
 
-        movdqu  xmm0, [rsp]
+        movdqa  xmm0, [rsp]
         add     rsp, 16
 
         pop     r10
@@ -475,6 +475,7 @@ LEAF_END_MARKED JIT_WriteBarrier, _TEXT
 LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
      // See if dst is in GCHeap
         PREPARE_EXTERNAL_VAR g_card_bundle_table, rax   // fetch the page byte map
+        mov     rax, [rax]
         mov     rcx,  rdi
         shr     rcx,  30                    // dst page index
         cmp     byte ptr [rax + rcx], 0

--- a/src/coreclr/vm/amd64/patchedcode.asm
+++ b/src/coreclr/vm/amd64/patchedcode.asm
@@ -385,7 +385,7 @@ endif
         ; also save xmm0, in case it is used for stack clearing, as JIT_ByRefWriteBarrier should not trash xmm0
         ; Hopefully EscapeFn cannot corrupt other xmm regs, since there is no float math or vectorizable code in there.
         sub     rsp, 16
-        movdqu  [rsp], xmm0
+        movdqa  [rsp], xmm0
 
         ; shadow space
         sub  rsp, 20h
@@ -395,7 +395,7 @@ endif
 
         add     rsp, 20h
 
-        movdqu  xmm0, [rsp]
+        movdqa  xmm0, [rsp]
         add     rsp, 16
 
         pop     r8


### PR DESCRIPTION
- fixes a typo in `ByRefWriteBarrier` on CoreCLR Unix x64  (missing rax deref that can cause crashes)
- uses movdqA when saving/restoring xmm via aligned location