### PR TITLE
Short circuit gen0 collection if surviving set is too large

### DIFF
--- a/src/coreclr/gc/satori/SatoriRegion.h
+++ b/src/coreclr/gc/satori/SatoriRegion.h
@@ -322,7 +322,7 @@ private:
 
     static void EscapeFn(SatoriObject** dst, SatoriObject* src, SatoriRegion* region);
 
-    void ThreadLocalMark();
+    bool ThreadLocalMark();
     void ThreadLocalPlan();
     void ThreadLocalUpdatePointers();
     void ThreadLocalCompact();


### PR DESCRIPTION
Gen0 accumulates reachable set size during marking. If too high, we bail out of Gen0 as it is going to be both expensive and ineffective.

Closes: #60