### PR TITLE
Inject `{SatoriGC, true}` into config values.

### DIFF
--- a/src/coreclr/gc/satori/SatoriGC.cpp
+++ b/src/coreclr/gc/satori/SatoriGC.cpp
@@ -733,6 +733,7 @@ int64_t SatoriGC::GetTotalPauseDuration()
 void SatoriGC::EnumerateConfigurationValues(void* context, ConfigurationValueFunc configurationValueFunc)
 {
     GCConfig::EnumerateConfigurationValues(context, configurationValueFunc);
+    configurationValueFunc(context, (void*)"SatoriGC", (void*)"SatoriGC", GCConfigurationType::Boolean, true);
 }
 
 bool SatoriGC::CheckEscapeSatoriRange(size_t dst, size_t src, size_t len)

--- a/src/coreclr/gc/satori/SatoriRecycler.cpp
+++ b/src/coreclr/gc/satori/SatoriRecycler.cpp
@@ -3501,7 +3501,9 @@ void SatoriRecycler::Plan()
     //
     // As crude criteria, we will do relocations if at least 1/2
     // of condemned regions want to participate. And at least 2.
-    size_t desiredRelocating = m_condemnedRegionsCount / 2 + 2;
+    size_t desiredRelocating = SatoriUtil::IsForceCompact() ?
+        0 :
+        m_condemnedRegionsCount / 2 + 2;
 
     if (m_isRelocating == false ||
         relocatableEstimate <= desiredRelocating)

--- a/src/coreclr/gc/satori/SatoriUtil.h
+++ b/src/coreclr/gc/satori/SatoriUtil.h
@@ -203,6 +203,12 @@ public:
         return (GCConfig::GetConcurrentGC());
     }
 
+    // DOTNET_gcForceCompact
+    static bool IsForceCompact()
+    {
+        return (GCConfig::GetForceCompact());
+    }
+
     // DOTNET_gcRelocatingGen1
     static bool IsRelocatingInGen1()
     {


### PR DESCRIPTION
As suggested in https://github.com/dotnet/runtime/discussions/115627?sort=new#discussioncomment-14099476

This allows to detect programmatically if an app uses Satori GC with code like:
```cs
 System.Console.WriteLine("Using Satori? " + GC.GetConfigurationVariables().ContainsKey("SatoriGC"));
```

The change also adds support for `DOTNET_gcForceCompact` knob, which forces compaction to happen more aggressively.