### PR TITLE
Fix osx-x64 cross compilation

### DIFF
--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -228,10 +228,10 @@ if(CLR_CMAKE_HOST_UNIX)
   add_compile_options($<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-conversion-null>)
   add_compile_options($<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-pointer-arith>)
 
-  if(CLR_CMAKE_TARGET_ARCH_AMD64 OR CLR_CMAKE_TARGET_ARCH_I386)
+  if(CLR_CMAKE_HOST_ARCH_AMD64 OR CLR_CMAKE_HOST_ARCH_I386)
     # Allow 16 byte compare-exchange
     add_compile_options(-mcx16)
-  endif(CLR_CMAKE_TARGET_ARCH_AMD64 OR CLR_CMAKE_TARGET_ARCH_I386)
+  endif(CLR_CMAKE_HOST_ARCH_AMD64 OR CLR_CMAKE_HOST_ARCH_I386)
 
   set (NATIVE_RESOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/nativeresources)
   include_directories(${NATIVE_RESOURCE_DIR})

--- a/src/coreclr/runtime/amd64/WriteBarriers.S
+++ b/src/coreclr/runtime/amd64/WriteBarriers.S
@@ -588,7 +588,7 @@ ALTERNATE_ENTRY RhpByRefAssignRefAVLocation2
         lea     r10, [rsi + 8]
         mov     rsi, [rsi]
 
-        call    RhpCheckedEntry
+        call    C_FUNC(RhpCheckedEntry)
 
         pop     r11
         pop     r10


### PR DESCRIPTION
I'm not entirely sure about the change to CMakeLists - running into a clang++ error: `unsupported option -mcx16 for target arm64-apple-darwin25.3.0`. Just referencing surrounding code which relates to the host.

While I'm PRing this to `main` (i.e. .NET 11), I've tested compilation on .NET 10 (our target SDK) here: https://github.com/ppy/Satori/actions/runs/27126600038 If this is accepted I can either backport to each of the branches as required or wait for you to do it.

Compile args: `./build.sh clr -c Release --cross -a x64`