### PR TITLE
Faster inline timer for deadline checks.

### DIFF
--- a/src/coreclr/gc/satori/SatoriAllocator.cpp
+++ b/src/coreclr/gc/satori/SatoriAllocator.cpp
@@ -130,14 +130,14 @@ tryAgain:
         // If someone else is reserving, we will allow 1 msec of retrying before reserving a page eagerly.
         if (newPageDeadline == 0)
         {
-            newPageDeadline = minipal_hires_ticks() + minipal_hires_tick_frequency() / 1000;
+            newPageDeadline = SatoriUtil::GetTimeStamp() + SatoriUtil::GetTimeStampFrequency() / 1000;
         }
 
         if (m_singePageAdders != 0 ||
             Interlocked::CompareExchange(&m_singePageAdders, 1, 0) != 0)
         {
             // someone is adding.
-            if (minipal_hires_ticks() - newPageDeadline > 0)
+            if (SatoriUtil::GetTimeStamp() - newPageDeadline > 0)
             {
                 // timed out
                 Interlocked::Increment(&m_singePageAdders);

--- a/src/coreclr/gc/satori/SatoriGC.cpp
+++ b/src/coreclr/gc/satori/SatoriGC.cpp
@@ -311,6 +311,7 @@ size_t SatoriGC::GetLastGCGenerationSize(int gen)
 
 HRESULT SatoriGC::Initialize()
 {
+    SatoriUtil::Initialize();
     SatoriObject::Initialize();
     SatoriHandlePartitioner::Initialize();
     m_heap = SatoriHeap::Create();

--- a/src/coreclr/gc/satori/SatoriHandlePartitioner.h
+++ b/src/coreclr/gc/satori/SatoriHandlePartitioner.h
@@ -89,7 +89,7 @@ public:
                     {
                         lambda(partition);
 
-                        if (deadline && (minipal_hires_ticks() - deadline > 0))
+                        if (deadline && (SatoriUtil::GetTimeStamp() - deadline > 0))
                         {
                             // timed out, there could be more work
                             return true;

--- a/src/coreclr/gc/satori/SatoriRecycler.cpp
+++ b/src/coreclr/gc/satori/SatoriRecycler.cpp
@@ -190,8 +190,8 @@ void SatoriRecycler::WorkerThreadMainLoop(void* param)
             }
 
             // spin for ~10 microseconds (GcSpin)
-            int64_t limit = minipal_hires_ticks() +
-                recycler->m_perfCounterTicksPerMicro * SatoriUtil::GcSpin();
+            int64_t limit = SatoriUtil::GetTimeStamp() +
+                SatoriUtil::GetTimeStampFrequency() / 1000000 * SatoriUtil::GcSpin();
 
             int i = 0;
             do
@@ -210,7 +210,7 @@ void SatoriRecycler::WorkerThreadMainLoop(void* param)
                     }
                 }
             }
-            while(minipal_hires_ticks() < limit);
+            while(SatoriUtil::GetTimeStamp() < limit);
 
             // Wait returns true if was woken up.
             if (!recycler->m_workerGate->TimedWait(10000))
@@ -527,7 +527,7 @@ bool IsWorkerThread()
 
 int64_t SatoriRecycler::HelpQuantum()
 {
-        return m_perfCounterTicksPerMilli /
+        return SatoriUtil::GetTimeStampFrequency() / 1000 /
             (IsWorkerThread() ?
                 8:  // 125 usec
                 64); // 15 usec
@@ -543,7 +543,7 @@ bool SatoriRecycler::HelpOnceCoreInner(bool minQuantum)
         BlockingMarkForConcurrentImpl();
     }
 
-    int64_t timeStamp = minipal_hires_ticks();
+    int64_t timeStamp = SatoriUtil::GetTimeStamp();
     int64_t deadline = timeStamp + (minQuantum ? 0: HelpQuantum());
 
     // this should be done before scanning stacks or cards
@@ -662,7 +662,7 @@ bool SatoriRecycler::HelpOnceCore(bool minQuantum)
         return true;
     }
 
-    int64_t start = minipal_hires_ticks();
+    int64_t start = SatoriUtil::GetTimeStamp();
 
     bool moreWork = !m_concurrentCardsDone ||
         m_ccStackMarkState != CC_MARK_STATE_DONE ||
@@ -745,12 +745,12 @@ void SatoriRecycler::HelpOnce()
                 return;
             }
 
-            int64_t start = minipal_hires_ticks();
+            int64_t start = SatoriUtil::GetTimeStamp();
 
             bool moreWork = HelpOnceCore(/*minQuantum*/ false);
             if (moreWork)
             {
-                m_noWorkSince = minipal_hires_ticks();
+                m_noWorkSince = SatoriUtil::GetTimeStamp();
             }
             else
             {
@@ -769,7 +769,7 @@ void SatoriRecycler::HelpOnce()
                 // consume what roughly remains for pacing reasons.
                 int64_t deadline = start + HelpQuantum() / 2;
                 int iters = 1;
-                while (minipal_hires_ticks() < deadline &&
+                while (SatoriUtil::GetTimeStamp() < deadline &&
                     m_ccStackMarkState != CC_MARK_STATE_SUSPENDING_EE)
                 {
                     iters *= 2;
@@ -785,7 +785,7 @@ void SatoriRecycler::HelpOnce()
     }
     else if (!m_deferredSweepRegions->IsEmpty())
     {
-        int64_t timeStamp = minipal_hires_ticks();
+        int64_t timeStamp = SatoriUtil::GetTimeStamp();
         int64_t deadline = timeStamp + HelpQuantum();
         DrainDeferredSweepQueueConcurrent(deadline);
     }
@@ -798,7 +798,7 @@ void SatoriRecycler::ConcurrentWorkerFn()
     {
         if (HelpOnceCore(/*minQuantum*/ false))
         {
-            m_noWorkSince = minipal_hires_ticks();
+            m_noWorkSince = SatoriUtil::GetTimeStamp();
         }
         else if (m_concurrentCleaningState == CC_CLEAN_STATE_NOT_READY)
         {
@@ -1799,7 +1799,7 @@ bool SatoriRecycler::MarkDemotedAndDrainQueuesConcurrent(int64_t deadline)
                 MarkDemoted(curRegion, &markContext);
                 PushToEphemeralQueues(curRegion);
 
-                if ((minipal_hires_ticks() - deadline) > 0)
+                if ((SatoriUtil::GetTimeStamp() - deadline) > 0)
                 {
                     if (markContext.m_WorkChunk != nullptr)
                     {
@@ -2156,9 +2156,9 @@ bool SatoriRecycler::DrainMarkQueuesConcurrent(SatoriWorkChunk* srcChunk, int64_
 
         // every once in a while check for the deadline.
         // check after processing one chunk to:
-        // - amortize cost of QueryPerformanceCounter() and
+        // - amortize cost of reading the timestamp and
         // - establish the minimum amount of work per help quantum
-        if ((minipal_hires_ticks() - deadline) > 0)
+        if ((SatoriUtil::GetTimeStamp() - deadline) > 0)
         {
             PushOrReturnWorkChunk(srcChunk);
             PushOrReturnWorkChunk(dstChunk);
@@ -2594,7 +2594,7 @@ bool SatoriRecycler::MarkThroughCardsConcurrent(int64_t deadline)
                         }
 
                         _ASSERTE(deadline != 0);
-                        if (minipal_hires_ticks() - deadline > 0)
+                        if (SatoriUtil::GetTimeStamp() - deadline > 0)
                         {
                             // timed out, there could be more work
                             // save where we would restart if we see this page again
@@ -2828,7 +2828,7 @@ bool SatoriRecycler::CleanCardsConcurrent(int64_t deadline)
                         }
 
                         _ASSERTE(deadline != 0);
-                        if (minipal_hires_ticks() - deadline > 0)
+                        if (SatoriUtil::GetTimeStamp() - deadline > 0)
                         {
                             // timed out, there could be more work
                             // save where we would restart if we see this page again
@@ -4452,7 +4452,7 @@ bool SatoriRecycler::DrainDeferredSweepQueueConcurrent(int64_t deadline)
                 Interlocked::Decrement(&m_deferredSweepCount);
 
                 // ignore deadline on worker threads, we can't do anything else anyways.
-                if (!isWorkerGCThread && deadline && (minipal_hires_ticks() - deadline > 0))
+                if (!isWorkerGCThread && deadline && (SatoriUtil::GetTimeStamp() - deadline > 0))
                 {
                     break;
                 }

--- a/src/coreclr/gc/satori/SatoriRecycler.cpp
+++ b/src/coreclr/gc/satori/SatoriRecycler.cpp
@@ -87,8 +87,9 @@ void SatoriRecycler::Initialize(SatoriHeap* heap)
 
     m_noWorkSince = 0;
 
-    m_perfCounterTicksPerMilli = minipal_hires_tick_frequency() / 1000;
-    m_perfCounterTicksPerMicro = minipal_hires_tick_frequency() / 1000000;
+    m_osTicksPerMilli = minipal_hires_tick_frequency() / 1000;
+    m_osTicksPerMicro = minipal_hires_tick_frequency() / 1000000;
+    m_timeStampTicksPerMilli = SatoriUtil::GetTimeStampFrequency() / 1000;
 
     m_heap = heap;
     m_trimmer = new (nothrow) SatoriTrimmer(heap);
@@ -190,8 +191,9 @@ void SatoriRecycler::WorkerThreadMainLoop(void* param)
             }
 
             // spin for ~10 microseconds (GcSpin)
-            int64_t limit = SatoriUtil::GetTimeStamp() +
-                SatoriUtil::GetTimeStampFrequency() / 1000000 * SatoriUtil::GcSpin();
+            // the OS timer here - only the clock ends this wait, so it must not be the inline one
+            int64_t limit = minipal_hires_ticks() +
+                recycler->m_osTicksPerMicro * SatoriUtil::GcSpin();
 
             int i = 0;
             do
@@ -210,7 +212,7 @@ void SatoriRecycler::WorkerThreadMainLoop(void* param)
                     }
                 }
             }
-            while(SatoriUtil::GetTimeStamp() < limit);
+            while(minipal_hires_ticks() < limit);
 
             // Wait returns true if was woken up.
             if (!recycler->m_workerGate->TimedWait(10000))
@@ -422,13 +424,13 @@ void SatoriRecycler::AddTenuredRegion(SatoriRegion* region)
 size_t SatoriRecycler::GetNowMillis()
 {
     int64_t t = minipal_hires_ticks();
-    return (size_t)(t / m_perfCounterTicksPerMilli);
+    return (size_t)(t / m_osTicksPerMilli);
 }
 
 size_t SatoriRecycler::GetNowUsecs()
 {
     int64_t t = minipal_hires_ticks();
-    return (size_t)(t / m_perfCounterTicksPerMicro);
+    return (size_t)(t / m_osTicksPerMicro);
 }
 
 size_t SatoriRecycler::IncrementGen0Count()
@@ -525,9 +527,17 @@ bool IsWorkerThread()
     return GCToEEInterface::WasCurrentThreadCreatedByGC();
 }
 
-int64_t SatoriRecycler::HelpQuantum()
+int64_t SatoriRecycler::HelpQuantumTimeStampTicks()
 {
-        return SatoriUtil::GetTimeStampFrequency() / 1000 /
+        return m_timeStampTicksPerMilli /
+            (IsWorkerThread() ?
+                8:  // 125 usec
+                64); // 15 usec
+}
+
+int64_t SatoriRecycler::HelpQuantumOsTicks()
+{
+        return m_osTicksPerMilli /
             (IsWorkerThread() ?
                 8:  // 125 usec
                 64); // 15 usec
@@ -544,7 +554,7 @@ bool SatoriRecycler::HelpOnceCoreInner(bool minQuantum)
     }
 
     int64_t timeStamp = SatoriUtil::GetTimeStamp();
-    int64_t deadline = timeStamp + (minQuantum ? 0: HelpQuantum());
+    int64_t deadline = timeStamp + (minQuantum ? 0: HelpQuantumTimeStampTicks());
 
     // this should be done before scanning stacks or cards
     // since the regions must be swept before we can use FindObject
@@ -588,7 +598,7 @@ bool SatoriRecycler::HelpOnceCoreInner(bool minQuantum)
         MarkOwnStackOrDrainQueuesConcurrent(deadline);
     }
 
-    if (m_ccStackMarkState == CC_MARK_STATE_SUSPENDING_EE && !IsWorkerThread())
+    if (AppThreadsShouldSuspend() && !IsWorkerThread())
     {
         // this is a mutator thread and we are suspending them, leave and suspend.
         return true;
@@ -662,7 +672,9 @@ bool SatoriRecycler::HelpOnceCore(bool minQuantum)
         return true;
     }
 
-    int64_t start = SatoriUtil::GetTimeStamp();
+    // paired with m_noWorkSince, which gates the escalation below - the OS timer
+    // so that a stalled inline counter cannot suppress it
+    int64_t start = minipal_hires_ticks();
 
     bool moreWork = !m_concurrentCardsDone ||
         m_ccStackMarkState != CC_MARK_STATE_DONE ||
@@ -715,7 +727,7 @@ bool SatoriRecycler::HelpOnceCore(bool minQuantum)
         m_workList->IsEmpty())
     {
         // was it long enough since last time we saw work?
-        if (start - m_noWorkSince > HelpQuantum() * 4)
+        if (start - m_noWorkSince > HelpQuantumOsTicks() * 4)
         {
             // 4 help quantums without work, seems like we are done
             // we may have some helpers draining long chains and not sharing anything
@@ -745,17 +757,17 @@ void SatoriRecycler::HelpOnce()
                 return;
             }
 
-            int64_t start = SatoriUtil::GetTimeStamp();
+            int64_t start = minipal_hires_ticks();
 
             bool moreWork = HelpOnceCore(/*minQuantum*/ false);
             if (moreWork)
             {
-                m_noWorkSince = SatoriUtil::GetTimeStamp();
+                m_noWorkSince = minipal_hires_ticks();
             }
             else
             {
                 // TODO: VS is this possible? should we do something like block?
-                //if (!moreWork && start - m_noWorkSince > m_perfCounterTicksPerMilli)
+                //if (!moreWork && start - m_noWorkSince > m_osTicksPerMilli)
                 //{
                 //    printf("PANIC\n");
                 //}
@@ -767,10 +779,10 @@ void SatoriRecycler::HelpOnce()
             {
                 // if we did not use all the quantum in Low Latency mode,
                 // consume what roughly remains for pacing reasons.
-                int64_t deadline = start + HelpQuantum() / 2;
+                int64_t deadline = start + HelpQuantumOsTicks() / 2;
                 int iters = 1;
-                while (SatoriUtil::GetTimeStamp() < deadline &&
-                    m_ccStackMarkState != CC_MARK_STATE_SUSPENDING_EE)
+                while (minipal_hires_ticks() < deadline &&
+                    !AppThreadsShouldSuspend())
                 {
                     iters *= 2;
                     for (int i = 0; i < iters; i++)
@@ -786,7 +798,7 @@ void SatoriRecycler::HelpOnce()
     else if (!m_deferredSweepRegions->IsEmpty())
     {
         int64_t timeStamp = SatoriUtil::GetTimeStamp();
-        int64_t deadline = timeStamp + HelpQuantum();
+        int64_t deadline = timeStamp + HelpQuantumTimeStampTicks();
         DrainDeferredSweepQueueConcurrent(deadline);
     }
 }
@@ -798,7 +810,7 @@ void SatoriRecycler::ConcurrentWorkerFn()
     {
         if (HelpOnceCore(/*minQuantum*/ false))
         {
-            m_noWorkSince = SatoriUtil::GetTimeStamp();
+            m_noWorkSince = minipal_hires_ticks();
         }
         else if (m_concurrentCleaningState == CC_CLEAN_STATE_NOT_READY)
         {
@@ -926,8 +938,8 @@ void SatoriRecycler::BlockingMarkForConcurrent()
         }
 
         size_t blockingDuration = (minipal_hires_ticks() - blockingStart);
-        m_CurrentGcInfo->m_pauseDurations[1] = blockingDuration / m_perfCounterTicksPerMicro;
-        m_gcAccmulatingDurationUsecs[m_condemnedGeneration] += blockingDuration / m_perfCounterTicksPerMicro;
+        m_CurrentGcInfo->m_pauseDurations[1] = blockingDuration / m_osTicksPerMicro;
+        m_gcAccmulatingDurationUsecs[m_condemnedGeneration] += blockingDuration / m_osTicksPerMicro;
         UpdateGcCounters(blockingStart);
 
         GCToEEInterface::RestartEE(false);
@@ -1203,9 +1215,9 @@ void SatoriRecycler::BlockingCollect1()
     BlockingCollectImpl();
 
     size_t blockingDuration = (minipal_hires_ticks() - blockingStart);
-    m_CurrentGcInfo->m_pauseDurations[0] = blockingDuration / m_perfCounterTicksPerMicro;
-    m_gcDurationUsecs[1] = blockingDuration / m_perfCounterTicksPerMicro;
-    m_gcAccmulatingDurationUsecs[1] += blockingDuration / m_perfCounterTicksPerMicro;
+    m_CurrentGcInfo->m_pauseDurations[0] = blockingDuration / m_osTicksPerMicro;
+    m_gcDurationUsecs[1] = blockingDuration / m_osTicksPerMicro;
+    m_gcAccmulatingDurationUsecs[1] += blockingDuration / m_osTicksPerMicro;
 
     size_t fromStartMillis = GetNowMillis() - m_startMillis;
     m_CurrentGcInfo->m_pausePercentage = (uint32_t)(m_gcAccmulatingDurationUsecs[1] / (int64_t)fromStartMillis / 10);
@@ -1228,9 +1240,9 @@ void SatoriRecycler::BlockingCollect2()
     BlockingCollectImpl();
 
     size_t blockingDuration = (minipal_hires_ticks() - blockingStart);
-    m_CurrentGcInfo->m_pauseDurations[0] = blockingDuration / m_perfCounterTicksPerMicro;
-    m_gcDurationUsecs[2] = blockingDuration / m_perfCounterTicksPerMicro;
-    m_gcAccmulatingDurationUsecs[2] += blockingDuration / m_perfCounterTicksPerMicro;
+    m_CurrentGcInfo->m_pauseDurations[0] = blockingDuration / m_osTicksPerMicro;
+    m_gcDurationUsecs[2] = blockingDuration / m_osTicksPerMicro;
+    m_gcAccmulatingDurationUsecs[2] += blockingDuration / m_osTicksPerMicro;
 
     size_t fromStartMillis = GetNowMillis() - m_startMillis;
     m_CurrentGcInfo->m_pausePercentage = (uint32_t)( m_gcAccmulatingDurationUsecs[2] / (int64_t)fromStartMillis / 10);
@@ -4572,14 +4584,14 @@ bool& SatoriRecycler::IsLowLatencyMode()
 void SatoriRecycler::UpdateGcCounters(int64_t blockingStart)
 {
     // Compute Time in GC
-    int64_t currentPerfCounterTimer = minipal_hires_ticks();
+    int64_t osNow = minipal_hires_ticks();
 
-    int64_t totalTimeInCurrentGc = currentPerfCounterTimer - blockingStart;
-    int64_t timeSinceLastGcEnded = currentPerfCounterTimer - m_totalTimeAtLastGcEnd;
+    int64_t totalTimeInCurrentGc = osNow - blockingStart;
+    int64_t timeSinceLastGcEnded = osNow - m_totalTimeAtLastGcEnd;
 
     // should always hold unless we switch to a nonmonotonic timer.
     _ASSERTE(timeSinceLastGcEnded >= totalTimeInCurrentGc);
 
     m_percentTimeInGcSinceLastGc = timeSinceLastGcEnded != 0 ? (int)(totalTimeInCurrentGc * 100 / timeSinceLastGcEnded) : 0;
-    m_totalTimeAtLastGcEnd = currentPerfCounterTimer;
+    m_totalTimeAtLastGcEnd = osNow;
 }

--- a/src/coreclr/gc/satori/SatoriRecycler.h
+++ b/src/coreclr/gc/satori/SatoriRecycler.h
@@ -161,6 +161,13 @@ public:
             &m_lastEphemeralGcInfo;
     };
 
+    // Two scenarios when worker threads should rather suspend thancontinue helping/pacing
+    bool AppThreadsShouldSuspend()
+    {
+        return m_gcState == GC_STATE_BLOCKING ||
+            m_ccStackMarkState == CC_MARK_STATE_SUSPENDING_EE;
+    }
+
 private:
     SatoriHeap* m_heap;
 
@@ -267,8 +274,9 @@ private:
     int64_t m_currentAllocBytesDeadThreads;
     int64_t m_totalAllocBytes;
 
-    int64_t m_perfCounterTicksPerMilli;
-    int64_t m_perfCounterTicksPerMicro;
+    int64_t m_osTicksPerMilli;
+    int64_t m_osTicksPerMicro;
+    int64_t m_timeStampTicksPerMilli;
 
     SatoriGate* m_workerGate;
 
@@ -306,7 +314,8 @@ private:
 
     static void WorkerThreadMainLoop(void* param);
     int MaxWorkers();
-    int64_t HelpQuantum();
+    int64_t HelpQuantumTimeStampTicks();
+    int64_t HelpQuantumOsTicks();
     void AskForHelp();
     void RunWithHelp(void(SatoriRecycler::* method)());
     bool HelpOnceCore(bool minQuantum);

--- a/src/coreclr/gc/satori/SatoriUtil.cpp
+++ b/src/coreclr/gc/satori/SatoriUtil.cpp
@@ -30,3 +30,125 @@
 #include "../env/gcenv.os.h"
 #include "SatoriUtil.h"
 
+#if defined(HOST_X86) || defined(HOST_AMD64)
+#include <minipal/cpuid.h>
+#endif
+
+int64_t SatoriUtil::s_timeStampFrequency = 0;
+int64_t SatoriUtil::s_osTimeStampFrequency = 0;
+
+// a counter that ticks slower than this is too coarse for the intervals that we measure.
+static const int64_t MIN_USABLE_FREQUENCY = 1000 * 1000;
+
+// a HW read that costs more than this is trapped, emulated or otherwise not what we are after.
+static const int64_t MAX_READ_NSEC = 200;
+
+// calibration reads per one check of the OS timer, so that its cost does not hide the cost of ours.
+static const int READ_BATCH = 64;
+
+// a measurement is inconclusive only if something interfered, so a few tries are plenty.
+static const int MAX_CALIBRATION_ATTEMPTS = 4;
+
+#if defined(HOST_X86) || defined(HOST_AMD64)
+
+// The TSC is only useful to us if it ticks at a constant rate regardless of the
+// core frequency and power state.
+static bool HasConstantRateTimeStamp()
+{
+    int regs[4];
+
+    __cpuid(regs, (int)0x80000000);
+    if ((uint32_t)regs[0] < 0x80000007)
+    {
+        return false;
+    }
+
+    __cpuid(regs, (int)0x80000007);
+    const int INVARIANT_TSC = 1 << 8;
+    return (regs[3] & INVARIANT_TSC) != 0;
+}
+
+#elif defined(HOST_ARM64)
+
+static bool HasConstantRateTimeStamp()
+{
+    // the counter is required to run at a constant rate.
+    return true;
+}
+
+#else
+
+static bool HasConstantRateTimeStamp()
+{
+    return false;
+}
+
+#endif
+
+// keeps the calibration reads from being optimized away.
+static volatile int64_t s_readSink;
+
+// Measures the counter rate and checks that reading it is actually cheap.
+// Returns 0 if the measurement was inconclusive.
+int64_t SatoriUtil::MeasureTimeStampFrequency()
+{
+    // ~100 usec gets the rate within ~0.05%, which is far more than deadlines need.
+    int64_t window = s_osTimeStampFrequency / 10000;
+    int64_t hwStart = ReadHwTimeStamp();
+    int64_t osStart = minipal_hires_ticks();
+    int64_t osNow;
+    int64_t reads = 0;
+    int64_t sink = 0;
+    do
+    {
+        for (int i = 0; i < READ_BATCH; i++)
+        {
+            sink += ReadHwTimeStamp();
+        }
+        reads += READ_BATCH;
+    } while ((osNow = minipal_hires_ticks()) - osStart < window);
+
+    s_readSink = sink;
+    int64_t hwElapsed = ReadHwTimeStamp() - hwStart;
+    int64_t osElapsed = osNow - osStart;
+
+    // Overshooting the window by this much means we were interrupted, so the numbers
+    // do not describe this machine. Bounding it also keeps the math below in range.
+    if (osElapsed > window * 4)
+    {
+        return 0;
+    }
+
+    if (osElapsed * 1000000000 / s_osTimeStampFrequency / reads > MAX_READ_NSEC)
+    {
+        return 0;
+    }
+
+    int64_t frequency = hwElapsed * s_osTimeStampFrequency / osElapsed;
+    return frequency >= MIN_USABLE_FREQUENCY ? frequency : 0;
+}
+
+void SatoriUtil::Initialize()
+{
+    s_osTimeStampFrequency = minipal_hires_tick_frequency();
+
+    // The choice is made once and for all - switching timers later would leave
+    // deadlines that were taken on one of them to be checked against the other.
+    if (HasConstantRateTimeStamp())
+    {
+        for (int i = 0; i < MAX_CALIBRATION_ATTEMPTS; i++)
+        {
+            s_timeStampFrequency = MeasureTimeStampFrequency();
+            if (s_timeStampFrequency != 0)
+            {
+                break;
+            }
+        }
+    }
+}
+
+int64_t SatoriUtil::GetTimeStampSlow()
+{
+    return minipal_hires_ticks();
+}
+

--- a/src/coreclr/gc/satori/SatoriUtil.cpp
+++ b/src/coreclr/gc/satori/SatoriUtil.cpp
@@ -94,9 +94,14 @@ int64_t SatoriUtil::MeasureTimeStampFrequency()
 {
     // ~100 usec gets the rate within ~0.05%, which is far more than deadlines need.
     int64_t window = s_osTimeStampFrequency / 10000;
-    int64_t hwStart = ReadHwTimeStamp();
+
+    // Read the OS timer on the outside of the counter at both ends, so that the interval
+    // attributed to the counter is contained in the interval measured with the OS timer.
+    // Bracketing it the other way round makes the counter's interval the larger of the
+    // two and reports its rate high by whatever the two gaps cost - measured at +0.2%
+    // typical, and always in the same direction.
     int64_t osStart = minipal_hires_ticks();
-    int64_t osNow;
+    int64_t hwStart = ReadHwTimeStamp();
     int64_t reads = 0;
     int64_t sink = 0;
     do
@@ -106,10 +111,13 @@ int64_t SatoriUtil::MeasureTimeStampFrequency()
             sink += ReadHwTimeStamp();
         }
         reads += READ_BATCH;
-    } while ((osNow = minipal_hires_ticks()) - osStart < window);
+    } while (minipal_hires_ticks() - osStart < window);
 
+    int64_t hwEnd = ReadHwTimeStamp();
+    int64_t osNow = minipal_hires_ticks();
     s_readSink = sink;
-    int64_t hwElapsed = ReadHwTimeStamp() - hwStart;
+
+    int64_t hwElapsed = hwEnd - hwStart;
     int64_t osElapsed = osNow - osStart;
 
     // Overshooting the window by this much means we were interrupted, so the numbers

--- a/src/coreclr/gc/satori/SatoriUtil.h
+++ b/src/coreclr/gc/satori/SatoriUtil.h
@@ -37,6 +37,13 @@
 #include <xmmintrin.h>
 #endif
 
+#if defined(HOST_ARM64) && defined(_MSC_VER)
+// the virtual counter of the ARM generic timer
+#ifndef ARM64_CNTVCT_EL0
+#define ARM64_CNTVCT_EL0 ARM64_SYSREG(3, 3, 14, 0, 2)
+#endif
+#endif
+
 namespace Satori
 {
     class StackOnly {
@@ -210,6 +217,36 @@ public:
         __builtin_prefetch(addr);
 #endif
     }
+
+    // A cheap monotonically increasing timestamp, for deadline checks and similar heuristics.
+    // This reads the hardware counter inline - typically just a few instructions.
+    //
+    // The counter may be slightly out of sync between cores and some parts are known to be
+    // unreliable, so do not use this where an occasional wrong reading is not tolerated.
+    // Durations that are reported or feed into heuristics should use the OS timer instead.
+    // The read is not serialized either, so it may drift within the out-of-order window.
+    //
+    // The unit is 1/GetTimeStampFrequency() of a second.
+    static FORCEINLINE int64_t GetTimeStamp()
+    {
+        // until the rate of the hardware counter is known, ask the OS instead.
+        if (s_timeStampFrequency == 0)
+        {
+            return GetTimeStampSlow();
+        }
+
+        return ReadHwTimeStamp();
+    }
+
+    // The number of GetTimeStamp() ticks per second.
+    static int64_t GetTimeStampFrequency()
+    {
+        return s_timeStampFrequency != 0 ? s_timeStampFrequency : s_osTimeStampFrequency;
+    }
+
+    // Chooses between the hardware counter and the OS timer and measures the rate of
+    // the former. Takes ~100 usec. Must be called before GetTimeStamp()/GetTimeStampFrequency().
+    static void Initialize();
 
     // Copies of InlinedForwardGCSafeCopyHelper/InlinedBackwardGCSafeCopyHelper from
     // vm/arraynative.inl - the VM headers are not reachable from the (standalone) GC.
@@ -642,6 +679,40 @@ public:
 
         return result;
     }
+
+private:
+    // the rate of the inline hardware counter, in Hz. 0 if we are not using it.
+    static int64_t s_timeStampFrequency;
+    static int64_t s_osTimeStampFrequency;
+
+    static int64_t MeasureTimeStampFrequency();
+
+    static FORCEINLINE int64_t ReadHwTimeStamp()
+    {
+#if defined(HOST_X86) || defined(HOST_AMD64)
+#ifdef _MSC_VER
+        return (int64_t)__rdtsc();
+#else
+        uint32_t lo, hi;
+        __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+        return (int64_t)(((uint64_t)hi << 32) | lo);
+#endif
+#elif defined(HOST_ARM64)
+#ifdef _MSC_VER
+        return (int64_t)_ReadStatusReg(ARM64_CNTVCT_EL0);
+#else
+        int64_t t;
+        __asm__ __volatile__("mrs %0, cntvct_el0" : "=r"(t));
+        return t;
+#endif
+#else
+        // unreachable - s_timeStampFrequency stays 0 when there is no inline counter.
+        return 0;
+#endif
+    }
+
+    NOINLINE
+    static int64_t GetTimeStampSlow();
 };
 
 #endif


### PR DESCRIPTION
Hardware registers are a very fast way to obtain a time stamp inline. 

There are reliability caveats in extreme corner cases - like buggy firmware, false or inaccessible frequency info, possible resets on PC sleep/wake, etc... All the stuff the OS timers needs to compensate for. 

We will use HW counters where we check deadline in scenarios that are ultimately bounded by the amount of work, thus even if counter stops updating (and, practically, it will not), we could still tolerate that relatively gracefully.
