### PR TITLE
[net10.0] Bump nuget version to build cleanly.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,7 +120,7 @@
     <SystemThreadingTasksExtensionsToolsetVersion>4.5.4</SystemThreadingTasksExtensionsToolsetVersion>
     <!-- Not auto-updated. -->
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderNativeVersion>17.12.0-beta1.24603.5</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>18.9.0-beta1.26405.2</MicrosoftDiaSymReaderNativeVersion>
     <TraceEventVersion>3.1.16</TraceEventVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>


### PR DESCRIPTION
Upstream already has this in main, but not in 10.0

bumping here to avoid restore failures until upstream addresses this one way or another:
https://github.com/dotnet/runtime/issues/133791